### PR TITLE
`KMS`を作成した

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,27 @@
+resource "aws_kms_key" "symmetric" {
+  description = "Symmetric encryption KMS key"
+}
+
+resource "aws_kms_alias" "symmetric_alias" {
+  name          = "alias/symmetric-${local.name_suffix}"
+  target_key_id = aws_kms_key.symmetric.key_id
+}
+
+resource "aws_kms_key_policy" "symmetric" {
+  key_id = aws_kms_key.symmetric.id
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+    ]
+    Version = "2012-10-17"
+  })
+}


### PR DESCRIPTION
closes #4 

# 料金
- AWS KMS で作成した各 AWS KMS キーには、1 USD/月のコスト
- ローテーションはしないので$0.00
- APIを叩いた時の料金
  - 10,000 件のリクエスト当たりUSD 0.03

# 仕様
- ローテションはしない
- 対称鍵にする
  - モチベーションとしてはECRの鍵のために作成した
  - ECRは対称鍵のみ対応なので
- ポリシー設定
  - ひとまずデフォルトの設定にする